### PR TITLE
coap / dtls: add artificial delay to DTLS's Server Hello Done

### DIFF
--- a/aiodnsprox/coap.py
+++ b/aiodnsprox/coap.py
@@ -168,5 +168,8 @@ class DNSOverCoAPServerFactory(BaseServerFactory):
 
         aiocoap.transports.tinydtls_server.securitystore = \
             self._CredentialStore()
+        # pylint: disable=protected-access
+        aiocoap.transports.tinydtls_server._SEND_SLEEP_WORKAROUND = \
+            Config().get('dtls', {}).get('server_hello_done_delay', 0.0)
         return await self.ClosableContext.create_server_context(site,
                                                                 local_addr)


### PR DESCRIPTION
Some links are not able to handle packets in such a rapid succession.
The Server Hello Done by DTLS is send directly after its Server Hello and thus can get lost. As a preliminary fix, an artificial delay to that particular Handshake message is added.