### PR TITLE
Various

### DIFF
--- a/aiodnsprox/cli/proxy.py
+++ b/aiodnsprox/cli/proxy.py
@@ -181,7 +181,10 @@ async def main():
     config = get_config(args)
 
     loop = asyncio.get_event_loop()
-    upstream = dns_upstream.DNSUpstream(**config['upstream_dns'])
+    if 'mock_dns_upstream' in config:
+        upstream = dns_upstream.MockDNSUpstream(**config['mock_dns_upstream'])
+    else:
+        upstream = dns_upstream.DNSUpstream(**config['upstream_dns'])
     for transport, args in config['transports'].items():
         factory = get_factory(upstream, transport)
         servers.append(await factory.create_server(

--- a/aiodnsprox/dns_upstream.py
+++ b/aiodnsprox/dns_upstream.py
@@ -9,7 +9,6 @@
 
 import asyncio
 import abc
-import copy
 import enum
 import typing
 import time
@@ -99,8 +98,7 @@ class DNSUpstream:
 
     @staticmethod
     def _resp_servfail(query):
-        resp = copy.deepcopy(query)
-        resp.flags = dns.flags.QR | dns.flags.RD | dns.flags.RA
+        resp = dns.message.make_response(query, recursion_available=True)
         resp.set_rcode(dns.rcode.SERVFAIL)
         return resp
 

--- a/tests/test_dns_upstream.py
+++ b/tests/test_dns_upstream.py
@@ -98,3 +98,150 @@ async def test_upstream_query_timeout(transport):
     response_bytes = await upstream.query(query.to_wire(), timeout=0.1)
     response = dns.message.from_wire(response_bytes)
     assert response.rcode() == dns.rcode.SERVFAIL
+
+
+def test_mock_upstream_init__unknown_address_type():
+    with pytest.raises(TypeError):
+        dns_upstream.MockDNSUpstream(IN={'A': dns.message.Message()})
+    with pytest.raises(TypeError):
+        dns_upstream.MockDNSUpstream(IN={'AAAA': dns.message.Message()})
+
+
+@pytest.mark.parametrize(
+    'A, AAAA',
+    [
+        ('10.0.0', None),
+        ('10.0.0.1.2', None),
+        (None, '2001:db8::1::1'),
+        ('2001:db8::1', '10.0.0.1'),
+        (b'\x0a\0\0\1\3', None),
+        (b'\x0a\0\0', None),
+        (None, b'\x20\x01\x0d\xb8' + (b'\0' * 11) + b'\1\3'),
+        (None, b'\x20\x01\x0d\xb8'),
+    ]   # pylint: disable=invalid-name
+)
+def test_mock_upstream_init__invalid_addresses(A, AAAA):
+    IN = {}   # pylint: disable=invalid-name
+    if A is not None:
+        IN['A'] = A
+    if AAAA is not None:
+        IN['AAAA'] = AAAA
+    with pytest.raises(ValueError):
+        dns_upstream.MockDNSUpstream(IN=IN)
+
+
+@pytest.mark.parametrize(
+    'A, AAAA',
+    [
+        (None, None),
+        ('10.0.0.1', None),
+        (None, '2001:db8::1'),
+        ('10.0.0.1', '2001:db8::1'),
+        (b'\x0a\0\0\1', None),
+        (None, b'\x20\x01\x0d\xb8' + (b'\0' * 11) + b'\1'),
+    ]   # pylint: disable=invalid-name
+)
+def test_mock_upstream_init__success(A, AAAA):
+    IN = {}   # pylint: disable=invalid-name
+    if A is not None:
+        IN['A'] = A
+    if AAAA is not None:
+        IN['AAAA'] = AAAA
+    upstream = dns_upstream.MockDNSUpstream(IN=IN)
+    if A is not None:
+        assert 'A' in upstream._IN      # pylint: disable=protected-access
+    if AAAA is not None:
+        assert 'AAAA' in upstream._IN   # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_mock_upstream_query_a():
+    IN = {'A': '10.0.0.1'}      # pylint: disable=invalid-name
+    upstream = dns_upstream.MockDNSUpstream(IN=IN)
+    found_answer = False
+    query = dns.message.make_query('example.org', 'A').to_wire()
+    response = dns.message.from_wire(await upstream.query(query))
+    for rset in response.answer:
+        for rda in rset:
+            if isinstance(rda, dns.rdtypes.IN.A.A):
+                found_answer = True
+                assert rda.address == IN['A']
+    assert found_answer
+
+
+@pytest.mark.asyncio
+async def test_mock_upstream_query_aaaa():
+    IN = {'AAAA': '2001:db8::1'}    # pylint: disable=invalid-name
+    upstream = dns_upstream.MockDNSUpstream(IN=IN)
+    found_answer = False
+    query = dns.message.make_query('example.org', 'AAAA').to_wire()
+    response = dns.message.from_wire(await upstream.query(query))
+    for rset in response.answer:
+        for rda in rset:
+            if isinstance(rda, dns.rdtypes.IN.AAAA.AAAA):
+                found_answer = True
+                assert rda.address == IN['AAAA']
+    assert found_answer
+
+
+@pytest.mark.asyncio
+async def test_mock_upstream_query_a_and_aaa():
+    IN = {                          # pylint: disable=invalid-name
+        'A': '10.0.0.1',
+        'AAAA': '::1',
+    }
+    upstream = dns_upstream.MockDNSUpstream(IN=IN)
+    found_answer = 0
+    query = dns.message.make_query('example.org', 'A')
+    query.find_rrset(query.question, dns.name.from_text('v6.example.org'),
+                     dns.rdataclass.IN, dns.rdatatype.AAAA, create=True,
+                     force_unique=True)
+    print(query)
+    response = dns.message.from_wire(await upstream.query(query.to_wire()))
+    for rset in response.answer:
+        for rda in rset:
+            if isinstance(rda, dns.rdtypes.IN.A.A):
+                found_answer += 1
+                assert rda.address == IN['A']
+            if isinstance(rda, dns.rdtypes.IN.AAAA.AAAA):
+                found_answer += 1
+                assert rda.address == IN['AAAA']
+    assert found_answer == 2
+
+
+@pytest.mark.asyncio
+async def test_mock_upstream_query_cname():
+    IN = {                          # pylint: disable=invalid-name
+        'A': '10.0.0.1',
+        'AAAA': '::1',
+    }
+    upstream = dns_upstream.MockDNSUpstream(IN=IN)
+    found_answer = 0
+    query = dns.message.make_query('example.org', 'CNAME')
+    response = dns.message.from_wire(await upstream.query(query.to_wire()))
+    for rset in response.answer:
+        for rda in rset:
+            if isinstance(rda, dns.rdtypes.IN.A.A):
+                found_answer += 1
+            if isinstance(rda, dns.rdtypes.IN.AAAA.AAAA):
+                found_answer += 1
+    assert found_answer == 0
+
+
+@pytest.mark.asyncio
+async def test_mock_upstream_query_non_in():
+    IN = {                          # pylint: disable=invalid-name
+        'A': '10.0.0.1',
+        'AAAA': '::1',
+    }
+    upstream = dns_upstream.MockDNSUpstream(IN=IN)
+    found_answer = 0
+    query = dns.message.make_query('example.org', 'CNAME', rdclass='CHAOS')
+    response = dns.message.from_wire(await upstream.query(query.to_wire()))
+    for rset in response.answer:
+        for rda in rset:
+            if isinstance(rda, dns.rdtypes.IN.A.A):
+                found_answer += 1
+            if isinstance(rda, dns.rdtypes.IN.AAAA.AAAA):
+                found_answer += 1
+    assert found_answer == 0

--- a/tests/test_dtls.py
+++ b/tests/test_dtls.py
@@ -98,7 +98,10 @@ def test_tinydtls_wrapper__write(caplog, mocker, config):
 
 
 @pytest.mark.asyncio
-async def test_dtls_proxy(dns_server, config):     # noqa: C901, F811
+@pytest.mark.parametrize(
+    'done_delay', [None, 0.0, 0.012]
+)
+async def test_dtls_proxy(dns_server, config, done_delay):  # noqa: C901, F811
     proxy_bind = ('::1', 2304)
     config.add_config({
         'dtls_credentials': {
@@ -106,6 +109,11 @@ async def test_dtls_proxy(dns_server, config):     # noqa: C901, F811
             'psk': 'secretPSK',
         }
     })
+
+    if done_delay is not None:
+        config.add_config({
+            'dtls': {'server_hello_done_delay': done_delay},
+        })
 
     class ClientProtocol(asyncio.DatagramProtocol):
         def __init__(self, loop, on_connection_lost):


### PR DESCRIPTION
- Provides a test case for the fix in #1
- Uses functionality of `dnspython` to create SERVFAIL response
- Provides mock DNS resolver (that always responds with the same A and AAAA records) as DNSUpstream child